### PR TITLE
 unlink @status.params from @searchParams

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -34,7 +34,7 @@ class Controller
 
     @status = $.extend true,
       {},
-      params: @searchParams
+      params: $.extend true, {}, @searchParams
     
     @reset()
 
@@ -231,7 +231,7 @@ class Controller
   reset: () ->
     queryCounter = @status.params.query_counter || 1
     @status =
-      params: @searchParams
+      params: $.extend true, {}, @searchParams
       currentPage: 0
       firstQueryTriggered: false
       lastPageReached: false


### PR DESCRIPTION
@ecoslado

I'm guessing:
   - `@searchParams` means **only** the params passed when calling the contructor or via `setSearchParam` method
   - `@status.params` doesn't have to have any reference to `@searchParams`


If that's the case, then `@status.params` and `@searchParams` were the same thing, and I propose to "uncouple" them in this PR . It hit hard during testing.