### PR TITLE
doc and code should agree....

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -108,7 +108,8 @@ class Controller
       @status.params.query = query
       @status.params.filters = $.extend true,
         {},
-        @searchParams.filters || {}
+        @searchParams.filters || {},
+        params.filters
       @status.params.query_counter = queryCounter
 
       if not @searchParams.query_name


### PR DESCRIPTION
according to doc, the `controller.search` method admits an options argument which is:

```html
An object with search parameters. You can use here all the parameters defined in Doofinder Search API.
```

so, `filters` which are search parameters described in Doofinder Search API, should be allowed , too, but the `search` method doesn't allow them


This PR is to put the code in line with the doc


But maybe what has to be  changed is the doc. @ecoslado , please think this a little in the light of the inner mechanisms of prefixed filters and the sort, you're more familiar with how the library handles that. I don't see any problem, but I don't trust my guts on this. (or any other thing, for that matter :-) )