### PR TITLE
 properly encapsulate attrib names within double quotes. fixes peilli…

### DIFF
--- a/src/widgets/facets/termfacet.coffee
+++ b/src/widgets/facets/termfacet.coffee
@@ -55,6 +55,7 @@ class TermFacet extends Display
       self.selected = {}
 
     # The filtering by click
+    # attr name within " in case a ' is inside
     @element.on 'click', "a[data-facet=\"#{@name}\"]", (e) ->
       e.preventDefault()
 

--- a/src/widgets/facets/termfacet.coffee
+++ b/src/widgets/facets/termfacet.coffee
@@ -55,7 +55,7 @@ class TermFacet extends Display
       self.selected = {}
 
     # The filtering by click
-    @element.on 'click', "a[data-facet='#{@name}']", (e) ->
+    @element.on 'click', "a[data-facet=\"#{@name}\"]", (e) ->
       e.preventDefault()
 
       value = $(this).data 'value'


### PR DESCRIPTION
…s/helpapp#4560

fixes peillis/helpapp#4560

the pont is: 

  - the whoe string must be double-quoted so there can be variable expansion
  - the attribute value must also be double-quoted in case its value has a `'`