### PR TITLE
Update jsDelivr links

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 Gruntfile.coffee
 src/
 test/
-dist/

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ This library allows you to make requests to your [Doofinder](http://www.doofinde
 `bower install doofinder`
 
 ### Downloadable minified javascript file
-https://cdn.jsdelivr.net/doofinder/latest/doofinder.min.js
+https://cdn.jsdelivr.net/npm/doofinder@latest/dist/doofinder.min.js
 
 ### CSS
 We offer some simple CSS. You can download it in the link
-https://cdn.jsdelivr.net/doofinder/latest/doofinder.css
+https://cdn.jsdelivr.net/npm/doofinder@latest/dist/doofinder.css
 
 
 ## Quick Start
@@ -48,7 +48,7 @@ Let's begin by showing a simple HTML template (myview.html):
 <html lang="en">
 <head>
 <script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script type="application/javascript" src="https://cdn.jsdelivr.net/doofinder/latest/doofinder.min.js"></script>
+<script type="application/javascript" src="https://cdn.jsdelivr.net/npm/doofinder@latest/dist/doofinder.min.js"></script>
 <script>
 (function(doofinder, document){
   $(document).ready(function(){

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.7",
   "description": "Javascript Library for Doofinder Search API",
   "main": "lib/doofinder.js",
+  "jsdelivr": "dist/doofinder.min.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links to use npm, but I noticed that `dist` directory was excluded from npm, so I had to change that too. The new link will work for all future version as soon as you publish a new version with `dist` directory included.

Feel free to ping me if you have any questions regarding this change.