### PR TITLE
build: iife build + demo refactoring

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,0 +1,12 @@
+function demo({ Client, Query, Zone }) {
+  const client = new Client(null, { zone: Zone.EU });
+  const query = new Query('c0604b71c273c1fb3ef13eb2adfa4452');
+
+  query.search('silla');
+  query.addFilter('brand', 'JANE');
+  query.addFilter('brand', 'RECARO');
+
+  client.search(query).then(result => {
+    console.log(result);
+  });
+}

--- a/demo/module.html
+++ b/demo/module.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Web Components Playground</title>
+  <script src="./demo.js"></script>
+  <script type="module">
+    import * as doofinder from '../lib/index.mjs';
+    demo(doofinder);
+  </script>
 </head>
 <body>
-  <ol>
-    <li><a href="./standalone.html">Standalone</a></li>
-    <li><a href="./module.html">Module</a></li>
-  </ol>
+  <a href="./index.html">← Back</a>
 </body>
 </html>

--- a/demo/standalone.html
+++ b/demo/standalone.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Web Components Playground</title>
+  <script src="../lib/doofinder.min.js"></script>
+  <script src="./demo.js"></script>
+  <script>
+    demo(doofinder);
+  </script>
 </head>
 <body>
-  <ol>
-    <li><a href="./standalone.html">Standalone</a></li>
-    <li><a href="./module.html">Module</a></li>
-  </ol>
+  <a href="./index.html">← Back</a>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Javascript Library for Doofinder Search API",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
+  "browser": "lib/doofinder.min.js",
   "engines": {
     "node": ">=10.15.0"
   },
@@ -18,10 +19,10 @@
   "types": "types/index.d.ts",
   "repository": "git@github.com:doofinder/js-doofinder.git",
   "scripts": {
-    "build": "yarn compile && yarn typings",
+    "build": "yarn compile && yarn minify-iife && yarn typings",
     "compile": "rimraf lib && rollup -c",
     "typings": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
-    "minify": "terser lib/index.mjs -c -m --comments /^nothing/",
+    "minify-iife": "terser lib/doofinder.js -c -m --comments /^nothing/ --keep-classnames --keep-fnames -o lib/doofinder.min.js",
     "lint": "eslint --env browser --fix src/**/*.ts",
     "test": "export TS_NODE_PROJECT=tsconfig.test.json ; mocha --reporter spec --require ts-node/register \"test/**/*.ts\"",
     "doc": "typedoc"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,16 +3,19 @@ import inject from 'rollup-plugin-inject';
 import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 
-function defaultPlugins(file) {
+function defaultPlugins(file, options = {}) {
   return [
     clear({
       targets: [file],
       watch: true
     }),
     resolve({
-      dedupe: ['qss']
+      dedupe: ['qss'],
+      browser: options.browser || false
     }),
-    typescript()
+    typescript({
+      typescript: require('typescript')
+    })
   ]
 }
 
@@ -28,12 +31,21 @@ export default [
   {
     input: 'src/index.ts',
     output: {
+      file: 'lib/doofinder.js',
+      format: 'iife',
+      name: 'doofinder'
+    },
+    plugins: defaultPlugins('lib/doofinder.js', { browser: true })
+  },
+  {
+    input: 'src/index.ts',
+    output: {
       file: 'lib/index.js',
       format: 'cjs'
     },
     external: [
       'node-fetch',
-      'qs'
+      'qss'
     ],
     plugins: defaultPlugins('lib/index.js').concat([
       inject({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "compilerOptions": {
-    "declaration": false,
-    "module": "ES2015",
     "noImplicitAny": true,
-    "outDir": "dist",
-    "target": "ES2015",
     "moduleResolution": "Node",
-    "experimentalDecorators": true,
-    "sourceMap": true
+    "module": "esnext",
+    "target": "esnext"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR:

- Adds a new standalone version of the library (publishes `window.doofinder`), both plain and minified.
- Adds a new demo for the standalone version. Both the module and the standalone version executes the same code so we can check they work the same.

Standalone, minified version is 8K in size (4K in gzip).