### PR TITLE
More refactoring

### DIFF
--- a/playground/standalone.html
+++ b/playground/standalone.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Web Components Playground</title>
-  <script src="../lib/doofinder.min.js"></script>
+  <script src="../lib/doofinder.js"></script>
   <script src="./demo.js"></script>
   <script>
     demo(doofinder);

--- a/src/doofinder.ts
+++ b/src/doofinder.ts
@@ -1,12 +1,4 @@
-import {
-  DoofinderParameters,
-  Zone,
-  GenericObject,
-  ClientOptions,
-  ClientResponseOrError,
-  ClientResponse,
-  ClientError,
-} from './types';
+import { DoofinderParameters, Zone, GenericObject, ClientOptions } from './types';
 
 import { Query } from './querybuilder/query';
 import { DoofinderResult } from './result';
@@ -21,6 +13,18 @@ interface DoofinderFullParameters extends DoofinderParameters {
 
 function isValidZone(zone: string): boolean {
   return Object.values(Zone).includes(zone as Zone);
+}
+
+export class ClientResponseError extends Error {
+  public statusCode: number;
+  public response: Response;
+
+  public constructor(response: Response) {
+    super(response.statusText);
+    this.name = 'ClientResponseError';
+    this.statusCode = response.status;
+    this.response = response;
+  }
 }
 
 /**
@@ -92,7 +96,12 @@ export class Client {
     this.endpoint = this.__buildEndpoint(serverAddress);
 
     this.hashid = hashid;
-    this.headers = Object.assign({}, headers || {});
+    this.headers = Object.assign(
+      {
+        Accept: 'application/json',
+      },
+      headers || {}
+    );
 
     if (this.secret) {
       this.headers['Authorization'] = this.secret;
@@ -104,36 +113,20 @@ export class Client {
    * options of the client.
    *
    * @param  {String}   resource Resource to be called by GET.
-   * @return {Promise<ClientResponseOrError>}
+   * @return {Promise<Response>}
    */
-  public async request(resource: string): Promise<ClientResponseOrError> {
-    const response: Response = await fetch(`${this.endpoint}${resource}`, {
+  public async request(resource: string): Promise<Response> {
+    const response = await fetch(resource, {
       method: 'GET',
+      mode: 'cors',
       headers: Object.assign({}, this.headers),
     });
 
     if (response.ok) {
-      return this.__buildResponse(response);
+      return response;
     } else {
-      return this.__buildError(response);
+      throw new ClientResponseError(response);
     }
-  }
-
-  private async __buildResponse(response: Response): Promise<ClientResponse> {
-    const data = await response.json();
-    return { statusCode: response.status, data };
-  }
-
-  private async __buildError(response: Response): Promise<ClientError> {
-    let data: object;
-
-    try {
-      data = await response.json();
-    } catch (_error) {
-      data = null;
-    }
-
-    return { statusCode: response.status, error: new Error(response.statusText), data };
   }
 
   //
@@ -168,25 +161,17 @@ export class Client {
    *                             the raw value returned by the endpoint. Defaults to true
    *
    *
-   * @return {Promise<ClientResponseOrError>}
+   * @return {Promise<Response>}
    */
   public async search(
     query: string | Query,
     params?: DoofinderParameters,
-    wrapper = true
-  ): Promise<ClientResponseOrError | DoofinderResult> {
-    const querystring: string = this.__buildSearchQueryString(query, params);
-    const response: ClientResponseOrError = await this.request(`/${this.version}/search?${querystring}`);
-
-    if (!wrapper) {
-      return response;
-    } else {
-      if (response.statusCode >= 200 && response.statusCode <= 299) {
-        return new DoofinderResult(response.data);
-      } else {
-        return response;
-      }
-    }
+    wrap = true
+  ): Promise<Response | DoofinderResult> {
+    const qs: string = this.buildSearchQueryString(query, params);
+    const response: Response = await this.request(this.buildUrl('/search', qs));
+    const data = await response.json();
+    return wrap ? new DoofinderResult(data) : data;
   }
 
   /**
@@ -198,11 +183,11 @@ export class Client {
    * @param  {Function} callback Callback to be called when the response is
    *                             received. First param is the error, if any,
    *                             and the second one is the response, if any.
-   * @return {Promise<ClientResponseOrError>}
+   * @return {Promise<Response>}
    */
-  public async options(suffix?: string): Promise<ClientResponseOrError> {
-    suffix = suffix ? `?${suffix}` : '';
-    return await this.request(`/${this.version}/options/${this.hashid}${suffix}`);
+  public async options(qs?: string): Promise<GenericObject> {
+    const response = await this.request(this.buildUrl(`/options/${this.hashid}`, qs));
+    return await response.json();
   }
 
   /**
@@ -213,18 +198,20 @@ export class Client {
    * @param  {Function} callback  Callback to be called when the response is
    *                              received. First param is the error, if any,
    *                              and the second one is the response, if any.
-   * @return {Promise<ClientResponseOrError>}
+   * @return {Promise<Response>}
    */
-  public async stats(eventName = '', params?: DoofinderParameters): Promise<ClientResponseOrError> {
+  public async stats(eventName = '', params?: DoofinderParameters): Promise<GenericObject> {
     const defaultParams: DoofinderFullParameters = {
       hashid: this.hashid,
       random: new Date().getTime(),
     };
-    let querystring = buildQueryString(Object.assign(defaultParams, params || {}));
-    if (querystring != null) {
-      querystring = `?${querystring}`;
-    }
-    return await this.request(`/${this.version}/stats/${eventName}${querystring}`);
+    const qs = buildQueryString(Object.assign(defaultParams, params || {}));
+    return await this.request(this.buildUrl(`/stats/${eventName}`, qs));
+  }
+
+  public buildUrl(resource: string, suffix?: string): string {
+    const qs = suffix ? `?${suffix}` : '';
+    return `${this.endpoint}/${this.version}${resource}${qs}`;
   }
 
   /**
@@ -251,7 +238,7 @@ export class Client {
    * @return {String}     Encoded query string to be used in a search URL.
    *
    */
-  private __buildSearchQueryString(query?: string | Query, params?: DoofinderParameters): string {
+  public buildSearchQueryString(query?: string | Query, params?: DoofinderParameters): string {
     let q: Query = new Query();
 
     // We get a no query

--- a/src/doofinder.ts
+++ b/src/doofinder.ts
@@ -209,8 +209,15 @@ export class Client {
     return await this.request(this.buildUrl(`/stats/${eventName}`, qs));
   }
 
-  public buildUrl(resource: string, suffix?: string): string {
-    const qs = suffix ? `?${suffix}` : '';
+  /**
+   *
+   * @param resource    URL part specifying the resource to be fetched from
+   *                    the current version of the API. Should start by '/'.
+   * @param querystring A query string to be attached to the URL. Should not
+   *                    start by '?'.
+   */
+  public buildUrl(resource: string, querystring?: string): string {
+    const qs = querystring ? `?${querystring}` : '';
     return `${this.endpoint}/${this.version}${resource}${qs}`;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,14 +157,3 @@ export type FacetOption = RangeFacet | string[] | number[];
 export interface Facet {
   [facetName: string]: FacetOption;
 }
-
-export interface ClientResponse {
-  statusCode: number;
-  data: GenericObject;
-}
-
-export interface ClientError extends ClientResponse {
-  error: Error;
-}
-
-export type ClientResponseOrError = ClientResponse | ClientError;

--- a/test/test_util_encode-params.ts
+++ b/test/test_util_encode-params.ts
@@ -22,9 +22,9 @@ describe("buildQueryString function", () => {
       c: 3
     }
 
-    const qs = buildQueryString(params).split('&');
+    const qs = buildQueryString(params);
 
-    // order is not guaranteed, so…
+    // order is not guaranteed for object keys, so…
     qs.should.include('a=1');
     qs.should.include('b=2');
     qs.should.include('c=3');
@@ -44,7 +44,9 @@ describe("buildQueryString function", () => {
     const params = {
       param: {a: 'abc', b: 'def'}
     }
-    buildQueryString(params).should.equal(butEncoded('param[a]=abc&param[b]=def'));
+    const qs = buildQueryString(params);
+    qs.should.include(butEncoded('param[a]=abc'));
+    qs.should.include(butEncoded('param[b]=def'));
     done();
   });
 
@@ -60,9 +62,8 @@ describe("buildQueryString function", () => {
       }
     }
 
-    const qs = buildQueryString(params).split('&');
+    const qs = buildQueryString(params);
 
-    qs.length.should.equal(12);
     qs.should.include(butEncoded('arr[0][a]=1'));
     qs.should.include(butEncoded('arr[0][b]=2'));
     qs.should.include(butEncoded('arr[1][c]=3'));
@@ -78,5 +79,4 @@ describe("buildQueryString function", () => {
 
     done();
   });
-  // it("");
 });

--- a/test/util/async.ts
+++ b/test/util/async.ts
@@ -1,0 +1,19 @@
+/**
+ * Method that allows performing tests against the result or error of an
+ * async method.
+ *
+ * The second parameter is a test function that receives two parameters:
+ *
+ * - Error instance, if any.
+ * - Result, if any.
+ *
+ * @param method Async method that will be tested.
+ * @param test Method that will perform tests.
+ */
+export async function expectAsync(method: Function, test: Function) {
+  try {
+    test(null, await method());
+  } catch (error) {
+    test(error, null);
+  }
+}


### PR DESCRIPTION
This PR refactors the requests so:

- The `request()` method returns a fetch `Response` other methods will use to get data.
- The `request()` method fails by throwing a custom error instance, so the response promise is rejected.

Regarding tests:

- Adapts tests to test async functions returning a rejected promise.
- Removes unneeded splits in params tests.

BREAKING changes:

- `search()` method's `wrapper` parameter has been renamed to `wrap`.
- `request()` method's result promise is rejected via an exception that must be catched from code using the client.