### PR TITLE
refactor: client refactoring

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -270,12 +270,12 @@ export class Client {
   public buildSearchQueryString(query: string | Query | DoofinderParameters, params?: DoofinderParameters): string {
     let q: Query = new Query();
 
-    if (query instanceof Query) {
-      q = query;
-    } else if (typeof query === 'string') {
+    if (typeof query === 'string') {
       q.searchText(query);
       q.load(params || {});
-    } else if (isPlainObject(query)) {
+    } else if (query instanceof Query) {
+      q = query;
+    } else {
       q.load(query || {});
     }
 


### PR DESCRIPTION
- Don't alter user data, the user is responsible of doing that.
- Removed `wrap` parameter. Always return `DoofinderResult`. The user can access `DoofinderResult.raw` to get the raw response. If we think `DoofinderResult` is not necessary then we'll have to remove it.
- Better specify overload calls in some methods.