### PR TITLE
refactor: client and stats client refactoring

### DIFF
--- a/playground/query.html
+++ b/playground/query.html
@@ -8,7 +8,7 @@
   <script type="module">
     import { Query } from '../lib/index.mjs';
 
-    const request = new Query({hashid: 'c0604b71c273c1fb3ef13eb2adfa4452'});
+    const request = new Query({hashid: '6a96504dc173514cab1e0198af92e6e9'});
     request.text = 'silla';
     request.page = 1;
     request.rpp = 100;

--- a/playground/stats.html
+++ b/playground/stats.html
@@ -6,9 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Doofinder Library Playground</title>
   <script type="module">
-    import { StatsClient } from '../lib/index.mjs';
+    import { pool } from '../lib/index.mjs';
 
-    const stats = new StatsClient('eu1');
+    const stats = pool.getStatsClient('eu1');
     window.stats = stats;
   </script>
 </head>

--- a/playground/stats.html
+++ b/playground/stats.html
@@ -8,7 +8,10 @@
   <script type="module">
     import { ClientPool } from '../lib/index.mjs';
 
+    const hashid = 'c0604b71c273c1fb3ef13eb2adfa4452';
     const stats = ClientPool.getStatsClient('eu1');
+
+    stats.client.options(hashid).then(value => console.log(value));
     window.stats = stats;
   </script>
 </head>

--- a/playground/stats.html
+++ b/playground/stats.html
@@ -5,13 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Doofinder Library Playground</title>
+  <script type="module">
+    import { StatsClient } from '../lib/index.mjs';
+
+    const stats = new StatsClient('eu1');
+    window.stats = stats;
+  </script>
 </head>
 <body>
-  <ol>
-    <li><a href="./standalone.html">Standalone</a></li>
-    <li><a href="./module.html">Module</a></li>
-    <li><a href="./query.html">Query</a></li>
-    <li><a href="./stats.html">Stats</a></li>
-  </ol>
+
 </body>
 </html>

--- a/playground/stats.html
+++ b/playground/stats.html
@@ -6,9 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Doofinder Library Playground</title>
   <script type="module">
-    import { pool } from '../lib/index.mjs';
+    import { ClientPool } from '../lib/index.mjs';
 
-    const stats = pool.getStatsClient('eu1');
+    const stats = ClientPool.getStatsClient('eu1');
     window.stats = stats;
   </script>
 </head>

--- a/playground/stats.html
+++ b/playground/stats.html
@@ -8,10 +8,12 @@
   <script type="module">
     import { ClientPool } from '../lib/index.mjs';
 
-    const hashid = 'c0604b71c273c1fb3ef13eb2adfa4452';
+    const hashid = '6a96504dc173514cab1e0198af92e6e9';
     const stats = ClientPool.getStatsClient('eu1');
+    const session_id = 'mysessid';
 
-    stats.client.options(hashid).then(value => console.log(value));
+    // waiting for API fix
+    stats.client.topStats('searches', { hashid, days: 7, withresult: true }).then(value => console.log(value));
     window.stats = stats;
   </script>
 </head>

--- a/src/client.ts
+++ b/src/client.ts
@@ -246,8 +246,9 @@ export class Client {
    *                             and the second one is the response, if any.
    * @return {Promise<Response>}
    */
-  public async options(hashid: string, qs?: string): Promise<GenericObject> {
+  public async options(hashid: string): Promise<GenericObject> {
     validateHashId(hashid);
+    const qs = buildQueryString({ random: new Date().getTime() });
     const response = await this.request(this.buildUrl(`/options/${hashid}`, qs));
     return await response.json();
   }
@@ -267,9 +268,8 @@ export class Client {
   // https://doofinder.github.io/js-doofinder/stats
 
   public async stats(eventName: string, params: GenericObject<string>): Promise<Response> {
-    const { hashid, session_id } = params;
-    validateRequired(session_id, 'session_id is required');
-    validateHashId(hashid);
+    validateRequired(params.session_id, 'session_id is required');
+    validateHashId(params.hashid);
     const qs = buildQueryString({ random: new Date().getTime(), ...params });
     return await this.request(this.buildUrl(`/stats/${eventName}`, qs));
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,13 @@ export class ClientResponseError extends Error {
   }
 }
 
+export type TopStatsType = 'searches' | 'clicks';
+export interface TopStatsParams {
+  hashid: string;
+  days?: number | string;
+  withresult?: boolean | string;
+}
+
 /**
  * This class allows searching and sending stats using the Doofinder service.
  */
@@ -272,6 +279,12 @@ export class Client {
     validateHashId(params.hashid);
     const qs = buildQueryString({ random: new Date().getTime(), ...params });
     return await this.request(this.buildUrl(`/stats/${eventName}`, qs));
+  }
+
+  public async topStats(type: TopStatsType, params: TopStatsParams): Promise<Response> {
+    validateHashId(params.hashid);
+    const qs = buildQueryString({ random: new Date().getTime(), ...params });
+    return await this.request(this.buildUrl(`/topstats/${type}`, qs));
   }
 
   /**

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -2,6 +2,11 @@ import { Zone } from './types';
 import { Client, ClientOptions } from './client';
 import { StatsClient } from './stats';
 
+/*
+  GOLDEN RULE: Do not save references to clients obtained from the pool,
+  always request new ones.
+*/
+
 /**
  * Manage clients for multiple zones as singletons with shared settings.
  *

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -7,27 +7,16 @@ import { StatsClient } from './stats';
  *
  * @beta
  */
-class ClientPoolSingleton {
-  private static _instance: ClientPoolSingleton;
-
-  private _clientsPool: Map<Zone, Client>;
-  private _statsClientsPool: Map<Zone, StatsClient>;
-  private _options: Partial<ClientOptions>;
+export class ClientPool {
+  private static _clientsPool: Map<Zone, Client> = new Map();
+  private static _statsClientsPool: Map<Zone, StatsClient> = new Map();
+  private static _options: Partial<ClientOptions> = {};
 
   /**
    * Build a new pool.
    */
   private constructor() {
-    this._clientsPool = new Map();
-    this._statsClientsPool = new Map();
-    this.reset();
-  }
-
-  public static getInstance(): ClientPoolSingleton {
-    if (this._instance == null) {
-      this._instance = new ClientPoolSingleton();
-    }
-    return this._instance;
+    throw new Error(`can't create instances of this class`);
   }
 
   /**
@@ -38,10 +27,10 @@ class ClientPoolSingleton {
    *
    * @beta
    */
-  public get options(): Partial<ClientOptions> {
+  public static get options(): Partial<ClientOptions> {
     return this._options;
   }
-  public set options(value: Partial<ClientOptions>) {
+  public static set options(value: Partial<ClientOptions>) {
     const { serverAddress, headers } = value;
     const options: Partial<ClientOptions> = {};
 
@@ -64,7 +53,7 @@ class ClientPoolSingleton {
    * @param zone - A valid search zone.
    * @beta
    */
-  public getClient(zone: Zone): Client {
+  public static getClient(zone: Zone): Client {
     if (!this._clientsPool.has(zone)) {
       this._clientsPool.set(zone, new Client({ ...this._options, zone }));
     }
@@ -72,7 +61,7 @@ class ClientPoolSingleton {
     return this._clientsPool.get(zone);
   }
 
-  public getStatsClient(zone: Zone): StatsClient {
+  public static getStatsClient(zone: Zone): StatsClient {
     if (!this._statsClientsPool.has(zone)) {
       this._statsClientsPool.set(zone, new StatsClient(this.getClient(zone)));
     }
@@ -80,16 +69,12 @@ class ClientPoolSingleton {
     return this._statsClientsPool.get(zone);
   }
 
-  public reset() {
+  public static reset() {
     this.options = {};
   }
 
-  public clear() {
+  public static clear() {
     this._clientsPool.clear();
     this._statsClientsPool.clear();
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ClientPool extends ClientPoolSingleton {}
-export const pool: ClientPool = ClientPoolSingleton.getInstance();

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,17 +1,12 @@
 import { Zone } from './types';
 import { Client, ClientOptions } from './client';
 
-export interface ClientPool {
-  options: Partial<ClientOptions>;
-  getClient(zone: Zone): Client;
-}
-
 /**
  * Manage clients for multiple zones as singletons with shared settings.
  *
  * @beta
  */
-class ClientPoolSingleton implements ClientPool {
+class ClientPoolSingleton {
   private static _instance: ClientPoolSingleton;
 
   private _pool: Map<Zone, Client>;
@@ -22,7 +17,7 @@ class ClientPoolSingleton implements ClientPool {
    */
   private constructor() {
     this._pool = new Map();
-    this.options = {};
+    this.reset();
   }
 
   public static getInstance(): ClientPoolSingleton {
@@ -57,7 +52,7 @@ class ClientPoolSingleton implements ClientPool {
 
     this._options = Object.freeze(options);
 
-    this._pool.clear();
+    this.clear();
   }
 
   /**
@@ -73,6 +68,16 @@ class ClientPoolSingleton implements ClientPool {
 
     return this._pool.get(zone);
   }
+
+  public reset() {
+    this.options = {};
+  }
+
+  public clear() {
+    this._pool.clear();
+  }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ClientPool extends ClientPoolSingleton {}
 export const pool: ClientPool = ClientPoolSingleton.getInstance();

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,7 +1,7 @@
 import { Client } from './client';
 import { pool } from './pool';
 import { GenericObject, StatsEvent, Zone } from './types';
-import { validateRequired, validateDoofinderId } from './util/validators';
+import { validateRequired, validateDoofinderId, ValidationError } from './util/validators';
 
 export interface StatsParams {
   session_id: string;
@@ -24,7 +24,11 @@ export class StatsClient {
   private _client: Client;
 
   public constructor(client: Client) {
-    this._client = client;
+    if (client instanceof Client) {
+      this._client = client;
+    } else {
+      throw new ValidationError(`expected an instance of Client`);
+    }
   }
 
   public get client(): Client {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,6 +1,5 @@
 import { Client } from './client';
-import { pool } from './pool';
-import { GenericObject, StatsEvent, Zone } from './types';
+import { GenericObject, StatsEvent } from './types';
 import { validateRequired, validateDoofinderId, ValidationError } from './util/validators';
 
 export interface StatsParams {
@@ -8,13 +7,20 @@ export interface StatsParams {
   hashid: string;
 }
 
-export interface ClickStatsParams extends StatsParams {
-  dfid?: string;
-  id?: string | number;
-  datatype?: string;
+export interface ClickStatsParamsDfid extends StatsParams {
+  dfid: string;
   query?: string;
   custom_results_id?: string | number;
 }
+
+export interface ClickStatsParamsId extends StatsParams {
+  id: string | number;
+  datatype: string;
+  query?: string;
+  custom_results_id?: string | number;
+}
+
+export type ClickStatsParams = ClickStatsParamsDfid | ClickStatsParamsId;
 
 export interface BannerStatsParams extends StatsParams {
   banner_id: string | number;
@@ -68,15 +74,21 @@ export class StatsClient {
    *
    */
   public async registerClick(params: ClickStatsParams): Promise<Response> {
-    try {
+    if ('dfid' in params) {
       validateDoofinderId(params.dfid);
+      /* eslint-disable @typescript-eslint/ban-ts-ignore */
+      // @ts-ignore
       delete params.id;
+      // @ts-ignore
       delete params.datatype;
-    } catch (e) {
+      /* eslint-enable @typescript-eslint/ban-ts-ignore */
+    } else {
       validateRequired([params.id, params.datatype], 'dfid or id + datatype are required');
+      /* eslint-disable @typescript-eslint/ban-ts-ignore */
+      // @ts-ignore
       delete params.dfid;
+      /* eslint-enable @typescript-eslint/ban-ts-ignore */
     }
-
     return this.client.stats(StatsEvent.Click, params as GenericObject);
   }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -21,14 +21,14 @@ export interface BannerStatsParams extends StatsParams {
 }
 
 export class StatsClient {
-  private _zone: Zone;
+  private _client: Client;
 
-  public constructor(zone: Zone) {
-    this._zone = zone;
+  public constructor(client: Client) {
+    this._client = client;
   }
 
   public get client(): Client {
-    return pool.getClient(this._zone);
+    return this._client;
   }
 
   /**

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,6 +1,25 @@
 import { Client } from './client';
-import { GenericObject, StatsEvent } from './types';
+import { GenericObject } from './types';
 import { validateRequired, validateDoofinderId, ValidationError } from './util/validators';
+
+export enum StatsEvent {
+  Init = 'init',
+  Click = 'click',
+  Checkout = 'checkout',
+  BannerDisplay = 'banner_display',
+  BannerClick = 'banner_click',
+}
+
+/*
+For banner displays:
+/5/stats/img_display?hashid=<hashid>&img_id=<img_id>
+
+For banner clicks:
+/5/stats/img_click?hashid=<hashid>&img_id=<img_id>
+
+For redirections:
+/5/stats/redirect?hashid=<hashid>&redirection_id=<redirection_id>&query=<term>&link=<link>
+*/
 
 export interface StatsParams {
   session_id: string;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -7,20 +7,20 @@ export interface StatsParams {
   hashid: string;
 }
 
-export interface ClickStatsParamsDfid extends StatsParams {
+export interface ClickStatsParamsWithDfid extends StatsParams {
   dfid: string;
   query?: string;
   custom_results_id?: string | number;
 }
 
-export interface ClickStatsParamsId extends StatsParams {
+export interface ClickStatsParamsWithId extends StatsParams {
   id: string | number;
   datatype: string;
   query?: string;
   custom_results_id?: string | number;
 }
 
-export type ClickStatsParams = ClickStatsParamsDfid | ClickStatsParamsId;
+export type ClickStatsParams = ClickStatsParamsWithDfid | ClickStatsParamsWithId;
 
 export interface BannerStatsParams extends StatsParams {
   banner_id: string | number;

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -7,18 +7,6 @@ export enum Zone {
 }
 
 /**
- * Types for the stats event
- *
- */
-export enum StatsEvent {
-  Init = 'init',
-  Click = 'click',
-  Checkout = 'checkout',
-  BannerDisplay = 'banner_display',
-  BannerClick = 'banner_click',
-}
-
-/**
  * This interface allow to use object[key: string] without
  * TypeScript giving problems about it.
  *

--- a/src/util/is.ts
+++ b/src/util/is.ts
@@ -23,12 +23,12 @@ const HASHID_REGEX = /^([0-9a-f]{32})(-.*)?/i;
  * doofinder ID
  *
  */
-export function isValidDoofinderId(value: string): boolean {
-  return DFID_REGEX.test(value);
+export function isValidDoofinderId(value: unknown): boolean {
+  return isString(value) && DFID_REGEX.test(value as string);
 }
 
-export function isValidHashId(value: string): boolean {
-  return HASHID_REGEX.test(value);
+export function isValidHashId(value: unknown): boolean {
+  return isString(value) && HASHID_REGEX.test(value as string);
 }
 /**
  * Copyright (c) 2013-present, Facebook, Inc.

--- a/src/util/validators.ts
+++ b/src/util/validators.ts
@@ -1,8 +1,8 @@
-import { isValidHashId, isValidDoofinderId } from './is';
+import { isValidHashId, isValidDoofinderId, isNumber } from './is';
 
 export class ValidationError extends Error {}
 
-export function validateHashId(hashid: string): boolean {
+export function validateHashId(hashid: unknown): boolean {
   if (hashid == null) {
     throw new ValidationError(`hashid parameter is mandatory`);
   } else if (!isValidHashId(hashid)) {
@@ -12,23 +12,23 @@ export function validateHashId(hashid: string): boolean {
   }
 }
 
-export function validatePage(page: number): boolean {
-  if (typeof page !== 'number' || page <= 0) {
+export function validatePage(page: unknown): boolean {
+  if (!isNumber(page) || page <= 0) {
     throw new ValidationError('page must be an integer greater than 0');
   } else {
     return true;
   }
 }
 
-export function validateRpp(rpp: number): boolean {
-  if (typeof rpp !== 'number' || rpp <= 0 || rpp > 100) {
+export function validateRpp(rpp: unknown): boolean {
+  if (!isNumber(rpp) || rpp <= 0 || rpp > 100) {
     throw new ValidationError('rpp must be a number between 1 and 100');
   } else {
     return true;
   }
 }
 
-export function validateDoofinderId(value: string): boolean {
+export function validateDoofinderId(value: unknown): boolean {
   if (!isValidDoofinderId(value)) {
     throw new ValidationError('invalid doofinder id');
   } else {

--- a/src/util/validators.ts
+++ b/src/util/validators.ts
@@ -1,4 +1,4 @@
-import { isValidHashId } from './is';
+import { isValidHashId, isValidDoofinderId } from './is';
 
 export class ValidationError extends Error {}
 
@@ -26,4 +26,24 @@ export function validateRpp(rpp: number): boolean {
   } else {
     return true;
   }
+}
+
+export function validateDoofinderId(value: string): boolean {
+  if (!isValidDoofinderId(value)) {
+    throw new ValidationError('invalid doofinder id');
+  } else {
+    return true;
+  }
+}
+
+export function validateRequired(values: unknown | unknown[], message: string): boolean {
+  const errors = (Array.isArray(values) ? values : [values]).filter(value => {
+    return value == null || (typeof value === 'string' && value.trim().length === 0);
+  });
+
+  if (errors.length > 0) {
+    throw new ValidationError(message);
+  }
+
+  return true;
 }

--- a/test/test_client.ts
+++ b/test/test_client.ts
@@ -144,25 +144,11 @@ describe('Client', () => {
       cfg.getClient().options('meh').should.be.rejectedWith(ValidationError).notify(done);
     });
 
-    it('works if called with hashid only', async () => {
+    it('works if called with valid hashid', done => {
       const url = `${cfg.endpoint}/5/options/${cfg.hashid}`;
-      fetchMock.get(url, {body: {}, status: 200});
-
-      const response = await cfg.getClient().options(cfg.hashid);
-
-      fetchMock.called(url).should.be.true;
-      expect(isPlainObject(response)).to.be.true;
-    });
-
-    it('works if called with a suffix', async () => {
-      const url = `${cfg.endpoint}/5/options/${cfg.hashid}?example.com`;
-      fetchMock.get(url, {body: {}, status: 200});
-
-      const client = cfg.getClient();
-      const response = await client.options(cfg.hashid, 'example.com');
-
-      fetchMock.called(url).should.be.true;
-      expect(isPlainObject(response)).to.be.true;
+      // @ts-ignore
+      fetchMock.get({url, query: {}}, {body: {}, status: 200});
+      cfg.getClient().options(cfg.hashid).should.be.fulfilled.notify(done);
     });
   });
 

--- a/test/test_client.ts
+++ b/test/test_client.ts
@@ -13,17 +13,18 @@ should();
 
 // required for tests
 import { Client, ClientResponseError } from '../src/client';
+import { ClientPool } from '../src/pool';
+import { isPlainObject } from '../src/util/is';
 import { Query } from '../src/query';
+import { StatsEvent } from '../src/stats';
+import { ValidationError } from '../src/util/validators';
+import { Zone } from '../src/types';
 
 // config, utils & mocks
 import * as cfg from './config';
 
 // Mock the fetch API
 import * as fetchMock from 'fetch-mock';
-import { Zone, StatsEvent } from '../src/types';
-import { isPlainObject } from '../src/util/is';
-import { ValidationError } from '../src/util/validators';
-import { ClientPool } from '../src/pool';
 
 // test
 describe('Client', () => {

--- a/test/test_client.ts
+++ b/test/test_client.ts
@@ -13,7 +13,7 @@ should();
 
 // required for tests
 import { Client, ClientResponseError } from '../src/client';
-import { Query, QueryParams } from '../src/query';
+import { Query } from '../src/query';
 
 // config, utils & mocks
 import * as cfg from './config';
@@ -23,12 +23,12 @@ import * as fetchMock from 'fetch-mock';
 import { Zone, StatsEvent } from '../src/types';
 import { isPlainObject } from '../src/util/is';
 import { ValidationError } from '../src/util/validators';
-import { pool } from '../src/pool';
+import { ClientPool } from '../src/pool';
 
 // test
 describe('Client', () => {
   afterEach(() => {
-    pool.reset();
+    ClientPool.reset();
     fetchMock.reset();
   });
 

--- a/test/test_client.ts
+++ b/test/test_client.ts
@@ -185,4 +185,26 @@ describe('Client', () => {
       cfg.getClient().stats(StatsEvent.Init, { hashid: cfg.hashid, session_id: 'abc'}).should.be.fulfilled.notify(done);
     });
   });
+
+  context('topStats()', () => {
+    const query = {
+      hashid: cfg.hashid,
+      days: '7',
+      withresults: 'true'
+    }
+
+    it('searches', done => {
+      const url = `${cfg.endpoint}/5/topstats/searches`;
+      // @ts-ignore
+      fetchMock.get({ url, query }, { body: {}, status: 200 });
+      cfg.getClient().topStats('searches', query).should.be.fulfilled.notify(done);
+    });
+
+    it('clicks', done => {
+      const url = `${cfg.endpoint}/5/topstats/clicks`;
+      // @ts-ignore
+      fetchMock.get({ url, query }, { body: {}, status: 200 });
+      cfg.getClient().topStats('clicks', query).should.be.fulfilled.notify(done);
+    });
+  });
 });

--- a/test/test_pool.ts
+++ b/test/test_pool.ts
@@ -5,40 +5,40 @@ import { should, expect } from 'chai';
 // chai
 should();
 
-import { pool } from '../src/pool';
+import { ClientPool } from '../src/pool';
 import { Zone } from '../src/types';
 
-describe('ClientPool', () => {
+describe('ClientClientPool', () => {
   it('creates clients with default options', (done) => {
-    let client = pool.getClient(Zone.EU1);
+    let client = ClientPool.getClient(Zone.EU1);
     client.endpoint.should.equal('//eu1-search.doofinder.com');
     Object.keys(client.headers).length.should.equal(1);
     client.headers.Accept.should.equal('application/json');
 
-    client = pool.getClient(Zone.US1);
+    client = ClientPool.getClient(Zone.US1);
     client.endpoint.should.equal('//us1-search.doofinder.com');
     done();
   });
 
   it('freezes pool options', done => {
-    pool.options = {
+    ClientPool.options = {
       headers: {
         'X-Whatever': 'value'
       }
     };
 
-    (() => { pool.options.key = 'blah' }).should.throw;
-    (() => { pool.options.headers['Other'] = 'value' }).should.throw;
-    (() => { pool.options.headers['X-Whatever'] = 'changed' }).should.throw;
+    (() => { ClientPool.options.key = 'blah' }).should.throw;
+    (() => { ClientPool.options.headers['Other'] = 'value' }).should.throw;
+    (() => { ClientPool.options.headers['X-Whatever'] = 'changed' }).should.throw;
 
-    Object.keys(pool.options).length.should.equal(1);
+    Object.keys(ClientPool.options).length.should.equal(1);
 
     done();
   });
 
   it('creates stats clients that depend on clients', done => {
-    let firstClient = pool.getClient(Zone.EU1);
-    let stats = pool.getStatsClient(Zone.EU1);
+    let firstClient = ClientPool.getClient(Zone.EU1);
+    let stats = ClientPool.getStatsClient(Zone.EU1);
 
     stats.client.should.equal(firstClient);
     expect(stats.client.secret).to.be.undefined;
@@ -46,13 +46,13 @@ describe('ClientPool', () => {
     firstClient.secret = 'abc';
     stats.client.secret.should.equal(firstClient.secret);
 
-    pool.options = {
+    ClientPool.options = {
       headers: {
         'X-Whatever': 'something'
       }
     }
 
-    stats = pool.getStatsClient(Zone.EU1);
+    stats = ClientPool.getStatsClient(Zone.EU1);
     stats.client.should.not.equal(firstClient);
     Object.keys(stats.client.headers).should.include('X-Whatever');
     expect(stats.client.secret).to.be.undefined;

--- a/test/test_pool.ts
+++ b/test/test_pool.ts
@@ -35,4 +35,28 @@ describe('ClientPool', () => {
 
     done();
   });
+
+  it('creates stats clients that depend on clients', done => {
+    let firstClient = pool.getClient(Zone.EU1);
+    let stats = pool.getStatsClient(Zone.EU1);
+
+    stats.client.should.equal(firstClient);
+    expect(stats.client.secret).to.be.undefined;
+
+    firstClient.secret = 'abc';
+    stats.client.secret.should.equal(firstClient.secret);
+
+    pool.options = {
+      headers: {
+        'X-Whatever': 'something'
+      }
+    }
+
+    stats = pool.getStatsClient(Zone.EU1);
+    stats.client.should.not.equal(firstClient);
+    Object.keys(stats.client.headers).should.include('X-Whatever');
+    expect(stats.client.secret).to.be.undefined;
+
+    done();
+  });
 });

--- a/test/test_stats_client.ts
+++ b/test/test_stats_client.ts
@@ -21,43 +21,15 @@ import { Zone, StatsEvent } from '../src/types';
 import { pool } from '../src/pool';
 import { ValidationError } from '../src/util/validators';
 
-describe('StatsClient', () => {
-  beforeEach(() => {
-    pool.reset();
-    // required to get https in requests and mocks to work
-    pool.getClient(Zone.EU1).secret = '0123456789abcdef';
-    pool.getClient(Zone.US1).secret = '0123456789abcdef';
-  });
+const client = new Client({ key: 'eu1-0123456789abcdef' });
+const stats = new StatsClient(client);
 
+describe('StatsClient', () => {
   afterEach(() => {
-    pool.reset();
     fetchMock.reset();
   });
 
-  context('client', () => {
-    it('is not affected by search client changes', done => {
-      pool.reset();
-
-      const stats = new StatsClient(Zone.EU1);
-      const client = stats.client;
-
-      Object.keys(stats.client.headers).length.should.equal(1);
-
-      pool.options = {
-        headers: {
-          'X-Whatever': 'some value'
-        }
-      }
-
-      stats.client.should.not.equal(client);
-      Object.keys(stats.client.headers).length.should.equal(2);
-      stats.client.headers['X-Whatever'].should.equal('some value');
-      done();
-    });
-  });
-
   context('session / checkout', () => {
-    const stats = new StatsClient(Zone.EU1);
     const query = {
       hashid: cfg.hashid,
       session_id: 'mysessionid'
@@ -77,8 +49,6 @@ describe('StatsClient', () => {
   });
 
   context('result clicks', () => {
-    const stats = new StatsClient(Zone.EU1);
-
     const url = `${cfg.endpoint}/5/stats/${StatsEvent.Click}`;
     const params = {
       session_id: 'mysessionid',
@@ -134,7 +104,6 @@ describe('StatsClient', () => {
   });
 
   context('banners', () => {
-    const stats = new StatsClient(Zone.EU1);
     const query = {
       session_id: 'mysessionid',
       hashid: cfg.hashid,

--- a/test/test_stats_client.ts
+++ b/test/test_stats_client.ts
@@ -80,11 +80,13 @@ describe('StatsClient', () => {
 
     it('should fail if no id is provided for the given datatype', done => {
       const query = { ...params, datatype };
+      // @ts-ignore
       stats.registerClick(query).should.be.rejectedWith(ValidationError).notify(done);
     });
 
     it('should fail if no datatype is provided for the given id', done => {
       const query = { ...params, id };
+      // @ts-ignore
       stats.registerClick(query).should.be.rejectedWith(ValidationError).notify(done);
     });
 

--- a/test/test_stats_client.ts
+++ b/test/test_stats_client.ts
@@ -17,8 +17,7 @@ import * as cfg from './config';
 
 // Mock the fetch API
 import * as fetchMock from 'fetch-mock';
-import { Zone, StatsEvent } from '../src/types';
-import { pool } from '../src/pool';
+import { StatsEvent } from '../src/types';
 import { ValidationError } from '../src/util/validators';
 
 const client = new Client({ key: 'eu1-0123456789abcdef' });

--- a/test/test_stats_client.ts
+++ b/test/test_stats_client.ts
@@ -10,15 +10,14 @@ should();
 
 // required for tests
 import { Client } from '../src/client';
-import { StatsClient } from '../src/stats';
+import { StatsClient, StatsEvent } from '../src/stats';
+import { ValidationError } from '../src/util/validators';
 
 // config, utils & mocks
 import * as cfg from './config';
 
 // Mock the fetch API
 import * as fetchMock from 'fetch-mock';
-import { StatsEvent } from '../src/types';
-import { ValidationError } from '../src/util/validators';
 
 const client = new Client({ key: 'eu1-0123456789abcdef' });
 const stats = new StatsClient(client);

--- a/test/test_validators.ts
+++ b/test/test_validators.ts
@@ -9,14 +9,14 @@ import { ValidationError, validateHashId, validateDoofinderId, validatePage, val
 
 describe('Validators', () => {
   it('validates hashids', done => {
-    validateHashId('c0604b71c273c1fb3ef13eb2adfa4452').should.be.true;
+    validateHashId('6a96504dc173514cab1e0198af92e6e9').should.be.true;
     (() => validateHashId(null)).should.throw(ValidationError);
     (() => validateHashId(undefined)).should.throw(ValidationError);
     (() => validateHashId('hello world')).should.throw(ValidationError);
     done();
   });
   it('validates dfids', done => {
-    validateDoofinderId(`c0604b71c273c1fb3ef13eb2adfa4452@product@a1d0c6e83f027327d8461063f4ac58a6`).should.be.true;
+    validateDoofinderId(`6a96504dc173514cab1e0198af92e6e9@product@a1d0c6e83f027327d8461063f4ac58a6`).should.be.true;
     (() => validateDoofinderId(null)).should.throw(ValidationError);
     (() => validateDoofinderId(undefined)).should.throw(ValidationError);
     (() => validateDoofinderId('hello world')).should.throw(ValidationError);

--- a/test/test_validators.ts
+++ b/test/test_validators.ts
@@ -1,0 +1,51 @@
+// required for testing
+import 'mocha';
+import { should, expect } from 'chai';
+
+// chai
+should();
+
+import { ValidationError, validateHashId, validateDoofinderId, validatePage, validateRpp, validateRequired } from '../src/util/validators';
+
+describe('Validators', () => {
+  it('validates hashids', done => {
+    validateHashId('c0604b71c273c1fb3ef13eb2adfa4452').should.be.true;
+    (() => validateHashId(null)).should.throw(ValidationError);
+    (() => validateHashId(undefined)).should.throw(ValidationError);
+    (() => validateHashId('hello world')).should.throw(ValidationError);
+    done();
+  });
+  it('validates dfids', done => {
+    validateDoofinderId(`c0604b71c273c1fb3ef13eb2adfa4452@product@a1d0c6e83f027327d8461063f4ac58a6`).should.be.true;
+    (() => validateDoofinderId(null)).should.throw(ValidationError);
+    (() => validateDoofinderId(undefined)).should.throw(ValidationError);
+    (() => validateDoofinderId('hello world')).should.throw(ValidationError);
+    done();
+  });
+  it('validates page param for searches', done => {
+    validatePage(14).should.be.true;
+    (() => validatePage(null)).should.throw(ValidationError);
+    (() => validatePage(undefined)).should.throw(ValidationError);
+    (() => validatePage('14')).should.throw(ValidationError);
+    (() => validatePage(-1)).should.throw(ValidationError);
+    done();
+  });
+  it('validates rpp param for searches', done => {
+    validateRpp(10).should.be.true;
+    (() => validateRpp(null)).should.throw(ValidationError);
+    (() => validateRpp(undefined)).should.throw(ValidationError);
+    (() => validateRpp('10')).should.throw(ValidationError);
+    (() => validateRpp(-1)).should.throw(ValidationError);
+    (() => validateRpp(101)).should.throw(ValidationError);
+    done();
+  });
+  it('validates required values', done => {
+    validateRequired(1, 'blah').should.be.true;
+    validateRequired([1, 2], 'blah').should.be.true;
+    (() => validateRequired(null, 'blah')).should.throw(ValidationError);
+    (() => validateRequired(undefined, 'blah')).should.throw(ValidationError);
+    (() => validateRequired([1, null], 'blah')).should.throw(ValidationError);
+    (() => validateRequired([undefined, 2], 'blah')).should.throw(ValidationError);
+    done();
+  });
+});


### PR DESCRIPTION
This code:

- Makes `Client` re-configurable after instantiation.
- Makes `StatsClient` a validation _proxy_ for `Client.stats` with less code.
- Makes `ClientPool` be able to provide instances of `StatsClient`.
- Adds tests but reducing the amount of code.
- Lacks a lot of comments.

**GOLDEN RULE: __Do not save references to clients obtained from the pool, always request new ones.__**