### PR TITLE
Refactor client constructor

### DIFF
--- a/bin/version.sh
+++ b/bin/version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+type jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+
+case "$1" in
+  major) RELEASE_TYPE_PARAM="--major" ;;
+  minor) RELEASE_TYPE_PARAM="--minor" ;;
+  patch) RELEASE_TYPE_PARAM="--patch" ;;
+  *)
+    echo >&2 "invalid release type (only 'patch', 'minor' and 'major' are valid). Aborting.";
+    exit 2;
+    ;;
+esac
+
+# get current version from package.json without quotes
+CURRENT_VERSION=`jq -r '.version' package.json`;
+# update version in package.json but don't commit
+yarn version $RELEASE_TYPE_PARAM --no-git-tag-version;
+# get updated version from package.json without quotes
+NEW_VERSION=`jq -r '.version' package.json`;
+# replace old version by the new one in index
+sed -i "" -E "s/$CURRENT_VERSION/$NEW_VERSION/g" src/index.ts;

--- a/doofinder.api.md
+++ b/doofinder.api.md
@@ -5,6 +5,12 @@
 ```ts
 
 // @public
+export const __VERSION__ = "6.0.0";
+
+// @public
+export const API_VERSION = 5;
+
+// @public
 export interface BannerInfo {
     blank: boolean;
     html_code: string;

--- a/doofinder.api.md
+++ b/doofinder.api.md
@@ -5,10 +5,10 @@
 ```ts
 
 // @public
-export const __VERSION__ = "6.0.0";
+export const __API_VERSION__ = 5;
 
 // @public
-export const API_VERSION = 5;
+export const __VERSION__ = "6.0.0";
 
 // @public
 export interface BannerInfo {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder",
-  "version": "6.0.1",
+  "version": "6.0.0",
   "description": "Javascript Library for Doofinder Search API",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "typings": "rimraf types && tsc --declaration --declarationMap --emitDeclarationOnly --outDir types && api-extractor run --local",
     "build": "yarn lint && yarn compile && yarn minify-iife && yarn typings",
     "docs": "api-documenter markdown -i ./temp -o ./docs/reference",
-    "test": "export TS_NODE_PROJECT=tsconfig.test.json ; mocha --reporter spec --require ts-node/register \"test/**/*.ts\""
+    "test": "export TS_NODE_PROJECT=tsconfig.test.json ; mocha --reporter spec --require ts-node/register \"test/**/*.ts\"",
+    "release:patch": "bin/version.sh patch && yarn build",
+    "release:minor": "bin/version.sh minor && yarn build",
+    "release:major": "bin/version.sh major && yarn build"
   },
   "author": "Doofinder",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Javascript Library for Doofinder Search API",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
@@ -21,15 +21,12 @@
   "scripts": {
     "dev": "es-dev-server --node-resolve --open /playground/",
     "dev:compat": "es-dev-server --node-resolve --compatibility esm --open /playground/",
-
     "lint": "eslint --env browser --fix src/**/*.ts",
     "compile": "rimraf lib && rollup -c",
     "minify-iife": "terser lib/doofinder.js -c -m --comments /^nothing/ --keep-classnames --keep-fnames -o lib/doofinder.min.js",
     "typings": "rimraf types && tsc --declaration --declarationMap --emitDeclarationOnly --outDir types && api-extractor run --local",
-
     "build": "yarn lint && yarn compile && yarn minify-iife && yarn typings",
     "docs": "api-documenter markdown -i ./temp -o ./docs/reference",
-
     "test": "export TS_NODE_PROJECT=tsconfig.test.json ; mocha --reporter spec --require ts-node/register \"test/**/*.ts\""
   },
   "author": "Doofinder",

--- a/src/client.ts
+++ b/src/client.ts
@@ -85,7 +85,6 @@ const API_KEY_RE = /^(([^-]+)-)?([a-f0-9]{40})$/i;
  * @public
  */
 export class Client {
-  private _version = 5;
   private _zone: string;
   private _secret: string;
   private _endpoint: string;
@@ -158,7 +157,7 @@ export class Client {
       protocol = 'https:';
     }
 
-    this._endpoint = `${protocol}//${address}`;
+    this._endpoint = `${protocol}//${address}/5`;
 
     this._headers = {
       Accept: 'application/json',
@@ -315,7 +314,7 @@ export class Client {
    */
   public buildUrl(resource: string, querystring?: string): string {
     const qs = querystring ? `?${querystring}` : '';
-    return `${this._endpoint}/${this._version}${resource}${qs}`;
+    return `${this.endpoint}/${resource}${qs}`;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import { validateHashId, validateRequired, ValidationError } from './util/valida
  * Version of the search API being used.
  * @public
  */
-export const API_VERSION = 5;
+export const __API_VERSION__ = 5;
 
 /**
  * Options that can be used to create a Client instance.
@@ -317,7 +317,7 @@ export class Client {
    */
   public buildUrl(resource: string, querystring?: string): string {
     const qs = querystring ? `?${querystring}` : '';
-    return `${this.endpoint}/${API_VERSION}${resource}${qs}`;
+    return `${this.endpoint}/${__API_VERSION__}${resource}${qs}`;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,9 @@ export * from './util/merge';
 
 export * from './types';
 export * from './response';
+
+/**
+ * Current version of the library.
+ * @public
+ */
+export const __VERSION__ = '6.0.0';

--- a/test/config.ts
+++ b/test/config.ts
@@ -7,5 +7,5 @@ export const zone = 'eu1';
 export const key = `${zone}-${secret}`;
 
 export const getClient = (): Client => {
-  return new Client({ secret: key });
+  return new Client({ zone, secret });
 }

--- a/test/test_client.ts
+++ b/test/test_client.ts
@@ -29,50 +29,45 @@ describe('Client', () => {
 
   context('Instantiation', () => {
     context('with no zone', () => {
-      it('should use EU1', done => {
-        (new Client()).zone.should.equal('eu1');
-        (new Client({ secret: cfg.secret })).zone.should.equal('eu1');
+      it('should throw', done => {
+        (() => new Client()).should.throw(ValidationError);
         done();
       });
     });
 
-    context('with key with zone and no zone', () => {
-      it('should use zone from key', done => {
-        const client = new Client({ secret: `us1-${cfg.secret}` });
+    context('with secret key', () => {
+      it('should use https', done => {
+        const client = new Client({ zone: 'eu1', secret: 'any' });
+        client.endpoint.substring(0, 6).should.equal('https:');
+        done();
+      });
+    });
+
+    context('with secret key with zone and zone', () => {
+      it("should use zone", done => {
+        const client = new Client({ zone: 'us1', secret: cfg.key });
         client.zone.should.equal('us1');
-        done();
-      })
-
-      it('should break if api key is malformed', done => {
-        (() => new Client({ secret: '-abcd' })).should.throw();
-        done();
-      });
-    });
-
-    context('with key with zone and zone', () => {
-      it("should use key's zone", done => {
-        const client = new Client({ secret: cfg.key, zone: 'us1' });
-        client.zone.should.equal('eu1');
         done();
       });
     });
 
     context('HTTP Headers', () => {
       it('should add passed headers to the request', done => {
-        const client = new Client({ secret: cfg.key, headers: { 'X-Name': 'John Smith' } });
+        const client = new Client({ zone: cfg.zone, headers: { 'X-Name': 'John Smith' } });
         client.headers['X-Name'].should.equal('John Smith');
         done()
       });
 
       it ("won't replace API Keys passed in options", done => {
         const client = new Client({
-          secret: cfg.key,
+          zone: cfg.zone,
+          secret: cfg.secret,
           headers: {
           'X-Name': 'John Smith',
           'Authorization': 'abc'
         }});
         client.headers['X-Name'].should.equal('John Smith');
-        client.headers.Authorization.should.equal('aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd');
+        client.headers.Authorization.should.equal('Token aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd');
         done();
       });
     });
@@ -85,8 +80,8 @@ describe('Client', () => {
       });
 
       it('should use custom address if defined', done => {
-        const client = new Client({ secret: cfg.key, serverAddress: 'localhost:4000' });
-        client.endpoint.should.equal('https://localhost:4000');
+        const client = new Client({ zone: cfg.zone, serverAddress: 'localhost:4000' });
+        client.endpoint.should.equal('//localhost:4000');
         done();
       });
     });

--- a/test/test_stats_client.ts
+++ b/test/test_stats_client.ts
@@ -9,7 +9,6 @@ use(chaiAsPromised);
 should();
 
 // required for tests
-import { Client } from '../src/client';
 import { StatsClient } from '../src/stats';
 import { ValidationError } from '../src/util/validators';
 
@@ -19,8 +18,7 @@ import * as cfg from './config';
 // Mock the fetch API
 import * as fetchMock from 'fetch-mock';
 
-const client = new Client({ secret: 'eu1-0123456789abcdef0123456789abcdef01234567' });
-const stats = new StatsClient(client);
+const stats = new StatsClient(cfg.getClient());
 
 describe('StatsClient', () => {
   afterEach(() => {


### PR DESCRIPTION
Rationale:

The new recommended format for authentication is:

```http
Authorization: Token {key}
```

This PR uses that format.

API keys work both with and without zone, so being too strict validating the API key is not practical, these formats are valid:

```http
Authorization: Token eu1-xxx…
Authorization: Token xxx…
```

This PR treats the token just as a string. If it's not valid the server will complain.

The search zone is now mandatory and it's not inferred from API key.