### PR TITLE
refactor: better normalization for terms facets

### DIFF
--- a/doofinder.api.md
+++ b/doofinder.api.md
@@ -105,6 +105,9 @@ export const decode: typeof qs.parse;
 export const encode: typeof qs.stringify;
 
 // @public
+export const extend: (...args: unknown[]) => any[] | Record<string, any>;
+
+// @public
 export type Facet = RangeFacet | TermsFacet;
 
 // @public
@@ -313,7 +316,11 @@ export interface RawSearchResponse extends Omit<SearchResponse, 'facets' | '_raw
 // @public
 export interface RawTermsFacet {
     doc_count: number;
+    // @beta
+    score?: number;
     selected: RawTermsInfo;
+    // @beta
+    slots?: boolean;
     terms: RawTermsInfo;
     total: {
         value: number;
@@ -330,7 +337,11 @@ export interface RawTermsInfo {
 // @public
 export interface RawTermStats {
     doc_count: number;
+    // @beta (undocumented)
+    from?: number;
     key: string;
+    // @beta (undocumented)
+    to?: number;
 }
 
 // @public
@@ -413,10 +424,8 @@ export interface TermsFacet {
 }
 
 // @public
-export interface TermStats {
+export interface TermStats extends RawTermStats {
     selected?: boolean;
-    total: number;
-    value: string;
 }
 
 // @public

--- a/test/fixtures/basic_response.ts
+++ b/test/fixtures/basic_response.ts
@@ -25,6 +25,60 @@ export const basicResponse: RawSearchResponse = {
         ],
       },
     },
+    price_range_slot: {
+      doc_count: null,
+      score: 99,
+      selected: {
+        buckets: [],
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0
+      },
+      slots: true,
+      terms: {
+        buckets: [
+          {
+            doc_count: null,
+            from: 0,
+            key: "0 - 20",
+            to: 20
+          },
+          {
+            doc_count: null,
+            from: 20,
+            key: "20 - 50",
+            to: 50
+          },
+          {
+            doc_count: null,
+            from: 50,
+            key: "50 - 90",
+            to: 90
+          },
+          {
+            doc_count: null,
+            from: 90,
+            key: "90 - 180",
+            to: 180
+          },
+          {
+            doc_count: null,
+            from: 180,
+            key: "180 - 540",
+            to: 540
+          },
+          {
+            doc_count: null,
+            from: 540,
+            key: "540"
+          }
+        ],
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0
+      },
+      total: {
+        value: null
+      }
+    },
     brand: {
       doc_count: 2295,
       selected: { buckets: [{ doc_count: 426, key: 'JANE' }], doc_count_error_upper_bound: 0, sum_other_doc_count: 0 },
@@ -58,9 +112,18 @@ export const basicResponse: RawSearchResponse = {
     },
     categories: {
       doc_count: 2295,
-      selected: { buckets: [], doc_count_error_upper_bound: 0, sum_other_doc_count: 0 },
+      selected: {
+        buckets: [
+          { doc_count: 915, key: 'Ofertas - Outlet' },
+          { doc_count: 419, key: 'Sillas de paseo' },
+          { doc_count: 1, key: 'Capazo solo' },
+        ],
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0
+      },
       terms: {
         buckets: [
+          { doc_count: 1, key: 'Capazo solo' }, // artifically added by the server
           { doc_count: 915, key: 'Ofertas - Outlet' },
           { doc_count: 881, key: 'Cochecitos de bebé' },
           { doc_count: 711, key: 'Sillas de paseo bebé' },

--- a/test/fixtures/basic_response.ts
+++ b/test/fixtures/basic_response.ts
@@ -123,6 +123,7 @@ export const basicResponse: RawSearchResponse = {
       },
       terms: {
         buckets: [
+          { doc_count: null, key: 'Special Value' },
           { doc_count: 1, key: 'Capazo solo' }, // artifically added by the server
           { doc_count: 915, key: 'Ofertas - Outlet' },
           { doc_count: 881, key: 'Cochecitos de bebé' },

--- a/test/test_response.ts
+++ b/test/test_response.ts
@@ -4,15 +4,21 @@ import { should, expect } from 'chai';
 import { basicResponse } from './fixtures/basic_response';
 
 import { _processSearchResponse, SearchResponse } from '../src/response';
+import { clone } from '../src/util/clone';
 
 // chai
 should();
 
 describe('Search Response', () => {
-  it('should properly transform facets', done => {
-    const response: SearchResponse = _processSearchResponse(basicResponse);
-    response._rawFacets.should.not.be.undefined;
-    response.facets.best_price.should.eql({
+  const response: SearchResponse = _processSearchResponse(clone(basicResponse));
+
+  it('should save a copy of received facets', done => {
+    response._rawFacets.should.eql(basicResponse.facets);
+    done();
+  });
+
+  it('should properly transform range facets', done => {
+    response.facets.best_price.should.be.eql({
       type: 'range',
       range: {
         avg: 283.44241397604185,
@@ -22,29 +28,78 @@ describe('Search Response', () => {
         sum: 650500.340075016
       }
     });
+    done();
+  });
+
+  it('should properly transform basic terms facets', done => {
     response.facets.brand.should.be.eql({
       type: 'terms',
       terms: [
-        { total: 426, value: 'JANE', selected: true },
-        { total: 275, value: 'BE COOL' },
-        { total: 253, value: 'CASUALPLAY' },
-        { total: 216, value: 'CONCORD' },
-        { total: 179, value: 'JOIE' },
-        { total: 126, value: 'MACLAREN' },
-        { total: 92, value: 'MIMA' },
-        { total: 92, value: 'RECARO' },
-        { total: 61, value: 'MOUNTAIN-BUGGY' },
-        { total: 52, value: 'BABYHOME' },
-        { total: 48, value: 'BABYJOGGER' },
-        { total: 43, value: 'BABYZEN' },
-        { total: 40, value: 'NURSE' },
-        { total: 32, value: 'CHICCO' },
-        { total: 29, value: 'KLIPPAN' },
-        { total: 26, value: 'AXKID' },
-        { total: 26, value: 'EASYWALKER' },
-        { total: 24, value: 'TRUNKI' },
-        { total: 22, value: 'KIWISAC' },
-        { total: 19, value: 'BABY MONSTERS' },
+        { doc_count: 426, key: 'JANE', selected: true },
+        { doc_count: 275, key: 'BE COOL' },
+        { doc_count: 253, key: 'CASUALPLAY' },
+        { doc_count: 216, key: 'CONCORD' },
+        { doc_count: 179, key: 'JOIE' },
+        { doc_count: 126, key: 'MACLAREN' },
+        { doc_count: 92, key: 'MIMA' },
+        { doc_count: 92, key: 'RECARO' },
+        { doc_count: 61, key: 'MOUNTAIN-BUGGY' },
+        { doc_count: 52, key: 'BABYHOME' },
+        { doc_count: 48, key: 'BABYJOGGER' },
+        { doc_count: 43, key: 'BABYZEN' },
+        { doc_count: 40, key: 'NURSE' },
+        { doc_count: 32, key: 'CHICCO' },
+        { doc_count: 29, key: 'KLIPPAN' },
+        { doc_count: 26, key: 'AXKID' },
+        { doc_count: 26, key: 'EASYWALKER' },
+        { doc_count: 24, key: 'TRUNKI' },
+        { doc_count: 22, key: 'KIWISAC' },
+        { doc_count: 19, key: 'BABY MONSTERS' },
+      ]
+    });
+    done();
+  });
+
+  it('should properly sort terms with unknown doc_count', done => {
+    response.facets.price_range_slot.should.be.eql({
+      type: 'terms',
+      terms: [
+        { doc_count: null, key: "0 - 20", from: 0, to: 20 },
+        { doc_count: null, key: "20 - 50", from: 20, to: 50 },
+        { doc_count: null, key: "50 - 90", from: 50, to: 90 },
+        { doc_count: null, key: "90 - 180", from: 90, to: 180 },
+        { doc_count: null, key: "180 - 540", from: 180, to: 540 },
+        { doc_count: null, key: "540", from: 540, }
+      ]
+    });
+    done();
+  });
+
+  it('should properly sort terms artifially added by the server', done => {
+    response.facets.categories.should.be.eql({
+      type: 'terms',
+      terms: [
+        { doc_count: 915, key: 'Ofertas - Outlet', selected: true },
+        { doc_count: 881, key: 'Cochecitos de bebé' },
+        { doc_count: 711, key: 'Sillas de paseo bebé' },
+        { doc_count: 632, key: 'Sillas de coche bebé' },
+        { doc_count: 603, key: 'Conjuntos de 2 o 3 piezas' },
+        { doc_count: 419, key: 'Sillas de paseo', selected: true },
+        { doc_count: 384, key: 'Individuales' },
+        { doc_count: 371, key: 'Cochecitos de bebé Jane' },
+        { doc_count: 311, key: 'Cochecitos bebé - Conjunto de 2 o 3 piezas' },
+        { doc_count: 288, key: 'Sillas de coche con isofix bebé' },
+        { doc_count: 275, key: 'Accesorios Cochecitos' },
+        { doc_count: 272, key: 'Sillas de coche y cochecitos Be Cool' },
+        { doc_count: 253, key: 'Conjuntos 2 piezas' },
+        { doc_count: 227, key: 'Cochecitos y sillas de coche Casualplay' },
+        { doc_count: 214, key: 'Conjuntos 3 piezas' },
+        { doc_count: 202, key: 'Sillas de coche sin isofix bebé' },
+        { doc_count: 193, key: 'Sillas de coche y cochecitos Concord' },
+        { doc_count: 178, key: 'Sillas de coche y sillas de paseo Joie' },
+        { doc_count: 135, key: 'Grupo 0-0+ (0 - 13kg)' },
+        { doc_count: 135, key: 'Grupo 2-3 (15 - 36kg)' },
+        { doc_count: 1, key: 'Capazo solo', selected: true }, // artifically added by the server
       ]
     });
     done();

--- a/test/test_response.ts
+++ b/test/test_response.ts
@@ -75,7 +75,7 @@ describe('Search Response', () => {
     done();
   });
 
-  it('should properly sort terms artifially added by the server', done => {
+  it('should properly sort terms artificially added by the server', done => {
     response.facets.categories.should.be.eql({
       type: 'terms',
       terms: [

--- a/test/test_response.ts
+++ b/test/test_response.ts
@@ -100,6 +100,7 @@ describe('Search Response', () => {
         { doc_count: 135, key: 'Grupo 0-0+ (0 - 13kg)' },
         { doc_count: 135, key: 'Grupo 2-3 (15 - 36kg)' },
         { doc_count: 1, key: 'Capazo solo', selected: true }, // artifically added by the server
+        { doc_count: null, key: 'Special Value' },
       ]
     });
     done();


### PR DESCRIPTION
Also replaced `nanoclone` by a port of `jQuery.extend` so cloning is more reliable.

**IMPORTANT:** This reverts the previous transformation of terms, so they have `doc_count` and `key` instead of `total` and `value` again.