### PR TITLE
fix: make query params validation more flexible

### DIFF
--- a/doofinder.api.md
+++ b/doofinder.api.md
@@ -232,11 +232,11 @@ export interface QueryParamsBase {
     hashid: string;
     items?: string[];
     nostats?: boolean;
-    page?: number;
+    page?: string | number;
     query?: string;
-    query_counter?: number;
+    query_counter?: string | number;
     query_name?: string;
-    rpp?: number;
+    rpp?: string | number;
     sort?: SortingInput[];
     transformer?: string;
     type?: string | string[];

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -19,9 +19,9 @@ export interface QueryParamsBase {
   /** Search terms. */
   query?: string;
   /** Results page to retrieve. */
-  page?: number;
+  page?: string | number;
   /** Number of results to retrieve for each page. */
-  rpp?: number;
+  rpp?: string | number;
   /** Name of the transformer to use to normalize the results. */
   transformer?: string;
 
@@ -30,7 +30,7 @@ export interface QueryParamsBase {
   /** Name of the query to use to get the results. */
   query_name?: string;
   /** Internal counter to manage request/response flow. */
-  query_counter?: number;
+  query_counter?: string | number;
   /** Whether to count the request in the search stats or not. */
   nostats?: boolean;
   /** Restrict the types of data to retrieve results. */
@@ -233,16 +233,16 @@ export class Query {
   public setParam(name: keyof QueryParams, value?: unknown): void {
     if (typeof value !== 'undefined') {
       if (name === 'hashid') {
-        validateHashId(value as string);
+        this._params.hashid = validateHashId(value as string);
       } else if (name === 'page') {
-        validatePage(value as number);
+        this._params.page = validatePage(value);
       } else if (name === 'rpp') {
-        validateRpp(value as number);
+        this._params.rpp = validateRpp(value);
       } else if (name === 'items') {
-        validateItems(value);
+        this._params.items = validateItems(value);
+      } else {
+        this._params[name] = value;
       }
-
-      this._params[name] = value;
     } else {
       delete this._params[name];
     }

--- a/src/util/is.ts
+++ b/src/util/is.ts
@@ -12,7 +12,8 @@ export const isString = (value: unknown): boolean => Object.prototype.toString.c
  * @returns `true` if the value is a number, `false` otherwise.
  * @public
  */
-export const isNumber = (value: unknown): boolean => Object.prototype.toString.call(value) === '[object Number]';
+export const isNumber = (value: unknown): boolean =>
+  Object.prototype.toString.call(value) === '[object Number]' && !isNaN(value as number);
 
 /**
  * Check if the provided value is an object.

--- a/src/util/validators.ts
+++ b/src/util/validators.ts
@@ -2,49 +2,55 @@ import { isValidHashId, isValidDoofinderId, isNumber } from './is';
 
 export class ValidationError extends Error {}
 
-export function validateHashId(hashid: unknown): boolean {
-  if (hashid == null) {
+export function validateHashId(value: unknown): string {
+  if (value == null) {
     throw new ValidationError(`hashid parameter is mandatory`);
-  } else if (!isValidHashId(hashid)) {
+  } else if (!isValidHashId(value)) {
     throw new ValidationError(`invalid hashid`);
   } else {
-    return true;
+    return value as string;
   }
 }
 
-export function validatePage(page: unknown): boolean {
-  if (typeof page !== 'undefined' && (!isNumber(page) || page <= 0)) {
-    throw new ValidationError('page must be an integer greater than 0');
-  } else {
-    return true;
+export function validatePage(value: unknown): number {
+  if (typeof value !== 'undefined') {
+    const page: number = parseInt(`${value}`, 10);
+    if (!isNumber(page) || page <= 0) {
+      throw new ValidationError('page must be an integer greater than 0');
+    } else {
+      return page;
+    }
   }
 }
 
-export function validateRpp(rpp: unknown): boolean {
-  if (typeof rpp !== 'undefined' && (!isNumber(rpp) || rpp <= 0 || rpp > 100)) {
-    throw new ValidationError('rpp must be a number between 1 and 100');
-  } else {
-    return true;
+export function validateRpp(value: unknown): number {
+  if (typeof value !== 'undefined') {
+    const rpp: number = parseInt(`${value}`, 10);
+    if (!isNumber(rpp) || rpp <= 0 || rpp > 100) {
+      throw new ValidationError('rpp must be a number between 1 and 100');
+    } else {
+      return rpp;
+    }
   }
 }
 
-export function validateDoofinderId(value: unknown): boolean {
+export function validateDoofinderId(value: unknown): string {
   if (!isValidDoofinderId(value)) {
     throw new ValidationError('invalid doofinder id');
   } else {
-    return true;
+    return value as string;
   }
 }
 
-export function validateItems(value: unknown): boolean {
+export function validateItems(value: unknown): string[] {
   if (!Array.isArray(value) || value.length !== value.filter(isValidDoofinderId).length) {
     throw new ValidationError(`items must be an array of doofinder ids`);
   } else {
-    return true;
+    return value as string[];
   }
 }
 
-export function validateRequired(values: unknown | unknown[], message: string): boolean {
+export function validateRequired(values: unknown | unknown[], message: string): unknown | unknown[] {
   const errors = (Array.isArray(values) ? values : [values]).filter(value => {
     return value == null || (typeof value === 'string' && value.trim().length === 0);
   });
@@ -53,5 +59,5 @@ export function validateRequired(values: unknown | unknown[], message: string): 
     throw new ValidationError(message);
   }
 
-  return true;
+  return values;
 }

--- a/test/test_query_builder.ts
+++ b/test/test_query_builder.ts
@@ -287,6 +287,14 @@ describe('Query', () => {
       query.dump().should.eql({...params, page: 3 });
       done();
     });
+
+    it('accepts page and rpp as string', done => {
+      const query = new Query();
+      query.load({ page: '42', rpp: '20'});
+      query.page.should.equal(42);
+      query.rpp.should.equal(20);
+      done();
+    })
   });
 
   context('copying', () => {

--- a/test/test_util_is.ts
+++ b/test/test_util_is.ts
@@ -65,6 +65,7 @@ describe("Is Module", () => {
     Thing.isNumber(NUMBER_SAMPLE_FLOAT).should.be.true;
     Thing.isNumber(null).should.be.false;
     Thing.isNumber(undefined).should.be.false;
+    Thing.isNumber(parseInt('hello', 10)).should.be.false;
     done();
   });
 });

--- a/test/test_validators.ts
+++ b/test/test_validators.ts
@@ -11,45 +11,46 @@ const DFID: string = `6a96504dc173514cab1e0198af92e6e9@product@a1d0c6e83f027327d
 
 describe('Validators', () => {
   it('validates hashids', done => {
-    validateHashId('6a96504dc173514cab1e0198af92e6e9').should.be.true;
+    const hashid: string = '6a96504dc173514cab1e0198af92e6e9';
+    validateHashId(hashid).should.equal(hashid);
     (() => validateHashId(null)).should.throw(ValidationError);
     (() => validateHashId(undefined)).should.throw(ValidationError);
     (() => validateHashId('hello world')).should.throw(ValidationError);
     done();
   });
   it('validates dfids', done => {
-    validateDoofinderId(DFID).should.be.true;
+    validateDoofinderId(DFID).should.equal(DFID);
     (() => validateDoofinderId(null)).should.throw(ValidationError);
     (() => validateDoofinderId(undefined)).should.throw(ValidationError);
     (() => validateDoofinderId('hello world')).should.throw(ValidationError);
     done();
   });
   it('validates page param for searches', done => {
-    validatePage(14).should.be.true;
-    validatePage(undefined).should.be.true;
+    validatePage(14).should.equal(14);
+    validatePage('14').should.equal(14);
+    expect(validatePage(undefined)).to.be.undefined;
     (() => validatePage(null)).should.throw(ValidationError);
-    (() => validatePage('14')).should.throw(ValidationError);
     (() => validatePage(-1)).should.throw(ValidationError);
     done();
   });
   it('validates rpp param for searches', done => {
-    validateRpp(10).should.be.true;
-    validateRpp(undefined).should.be.true;
+    validateRpp(10).should.equal(10);
+    validateRpp('10').should.equal(10);
+    expect(validateRpp(undefined)).to.be.undefined;
     (() => validateRpp(null)).should.throw(ValidationError);
-    (() => validateRpp('10')).should.throw(ValidationError);
     (() => validateRpp(-1)).should.throw(ValidationError);
     (() => validateRpp(101)).should.throw(ValidationError);
     done();
   });
   it('validates items param for searches', done => {
-    validateItems([DFID]).should.be.true;
+    validateItems([DFID]).should.eql([DFID]);
     (() => validateItems([DFID, `hello world`])).should.throw(ValidationError);
     (() => validateItems([42])).should.throw(ValidationError);
     done();
   });
   it('validates required values', done => {
-    validateRequired(1, 'blah').should.be.true;
-    validateRequired([1, 2], 'blah').should.be.true;
+    validateRequired(1, 'blah').should.equal(1);
+    validateRequired([1, 2], 'blah').should.eql([1, 2]);
     (() => validateRequired(null, 'blah')).should.throw(ValidationError);
     (() => validateRequired(undefined, 'blah')).should.throw(ValidationError);
     (() => validateRequired([1, null], 'blah')).should.throw(ValidationError);


### PR DESCRIPTION
If you do:

```js
import { encode, decode, Query } from 'doofinder';
const data = { page: 10 };
const query = new Query(decode(encode(data)));
```

… you get an error because `decode()` doesn't know the type for the `page` key and converts it to a string.

Now validators handle type casting when possible and returns the final value so they can be used just for validation or for validation + normalization.